### PR TITLE
Remove visual flash.

### DIFF
--- a/components/t547/t547.cpp
+++ b/components/t547/t547.cpp
@@ -75,7 +75,8 @@ void T547::display() {
   uint32_t start_time = millis();
 
   epd_poweron();
-  epd_clear();
+  //epd_clear();
+  epd_draw_image(epd_full_screen(), this->buffer_, WHITE_ON_BLACK);
   epd_draw_grayscale_image(epd_full_screen(), this->buffer_);
   epd_poweroff();
 


### PR DESCRIPTION
This removes the jarring visual flash, by drawing a white screen based on the buffer, then drawing the screen in full.  This means you no longer need to fully clear the screen on each draw.  This removes the visual black/white flash you see when calling epd_clear();  Obviously this wouldn't work for Black on White renders.