### PR TITLE
Rename DisplayBufferRef to DisplayRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ external_components:
   - source: github://nickolay/esphome-lilygo-t547plus
     components: ["t547"]
 
+## for those using ESPHome 2023.6.5 and earlier:
+# external_components:
+#   - source: github://nickolay/esphome-lilygo-t547plus@2023.6.5
+#     components: [t547]
+
+
 display:
 - platform: t547
   id: t5_display

--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -39,7 +39,7 @@ async def to_code(config):
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
-            config[CONF_LAMBDA], [(display.DisplayBufferRef, "it")], return_type=cg.void
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
 


### PR DESCRIPTION
## What

Renames `DisplayBufferRef` to `DisplayRef` in `display.py`

## Why

See https://github.com/esphome/esphome/pull/5002 for breaking change in esphome.