### PR TITLE
Pin the toolchain-riscv32-esp package to avoid build problems.

### DIFF
--- a/basic.yaml
+++ b/basic.yaml
@@ -13,6 +13,8 @@ esphome:
     board_build.psram_type: opi
     board_build.memory_type: qspi_opi
     board_build.boot_freq: 80m
+    platform_packages:
+      - "toolchain-riscv32-esp @8.4.0+2021r2-patch5"
     build_flags:  # the first three defines are required for the screen library to function.
       - "-DBOARD_HAS_PSRAM"
       - "-DARDUINO_RUNNING_CORE=0"  # TODO: this conflicts with the value from platformio's idedata, spewing a lot of warnings during the build.


### PR DESCRIPTION
I hit an error when building with esphome 2023.10.3 from this example `basic.yaml`. Something similar to:

```
Error: Could not find the package with 'espressif/toolchain-riscv32-esp @ 8.4.0+2021r2-patch2' requirements for your system 'linux_x86_64'
```

After some research I found a similar issue here: https://github.com/mmakaay/esphome-xiaomi_bslamp2/issues/116 and here: https://github.com/platformio/platform-espressif32/issues/1081

It seems like pinning a specific version of that package solves this problem. I don't know why, but after making this change the image builds and runs. 