### PR TITLE
Compatability fix for ESPHome 2023.12

### DIFF
--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -34,7 +34,8 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    await cg.register_component(var, config)
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
     await display.register_display(var, config)
 
     if CONF_LAMBDA in config:

--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_PAGES,
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 DEPENDENCIES = ["esp32"]
 

--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -12,7 +12,11 @@
 namespace esphome {
 namespace t547 {
 
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class T547 : public display::DisplayBuffer {
+#else
 class T547 : public PollingComponent, public display::DisplayBuffer {
+#endif  // VERSION_CODE(2023, 12, 0)
  public:
   void set_greyscale(bool greyscale) {
     this->greyscale_ = greyscale;


### PR DESCRIPTION
I did the same changes as this pull request: https://github.com/landonr/lilygo-tdisplays3-esphome/pull/46

It seems to work fine on my display