### PR TITLE
Add quick display update

### DIFF
--- a/components/t547/display.py
+++ b/components/t547/display.py
@@ -6,13 +6,14 @@ from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
     CONF_PAGES,
+    CONF_FULL_UPDATE_EVERY,
 )
 from esphome.const import __version__ as ESPHOME_VERSION
 
 DEPENDENCIES = ["esp32"]
 
 CONF_GREYSCALE = "greyscale"
-
+CONF_QUICK_UPDATING = "quick_updating"
 
 t547_ns = cg.esphome_ns.namespace("t547")
 T547 = t547_ns.class_(
@@ -24,6 +25,8 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(T547),
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
+            cv.Optional(CONF_FULL_UPDATE_EVERY, default=5): cv.uint32_t,
+            cv.Optional(CONF_QUICK_UPDATING, default=False): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("5s")),
@@ -46,7 +49,8 @@ async def to_code(config):
         cg.add(var.set_writer(lambda_))
 
     cg.add(var.set_greyscale(config[CONF_GREYSCALE]))
-
+    cg.add(var.set_quick_updating(config[CONF_QUICK_UPDATING]))
+    cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
     cg.add_build_flag("-DBOARD_HAS_PSRAM")
 
     cg.add_library("Wire", version="2.0.0")  # required by LilyGoEPD47

--- a/components/t547/t547.cpp
+++ b/components/t547/t547.cpp
@@ -14,6 +14,7 @@ static const char *const TAG = "t574";
 void T547::setup() {
   ESP_LOGV(TAG, "Initialize called");
   epd_init();
+  epd_clear();
   uint32_t buffer_size = this->get_buffer_length_();
 
   if (this->buffer_ != nullptr) {
@@ -75,7 +76,17 @@ void T547::display() {
   uint32_t start_time = millis();
 
   epd_poweron();
-  epd_clear();
+  if(!quick_updating_ || quick_updates_ > full_update_every_)
+  {
+    epd_clear();
+    quick_updates_ = 0;
+  }
+  else
+  {
+    epd_draw_image(epd_full_screen(), this->buffer_, WHITE_ON_BLACK);
+    quick_updates_++;
+  }
+
   epd_draw_grayscale_image(epd_full_screen(), this->buffer_);
   epd_poweroff();
 

--- a/components/t547/t547.h
+++ b/components/t547/t547.h
@@ -21,7 +21,8 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
   void set_greyscale(bool greyscale) {
     this->greyscale_ = greyscale;
   }
-
+  void set_quick_updating(bool quick_updating) { this->quick_updating_ = quick_updating; }
+  void set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
   float get_setup_priority() const override;
 
   void dump_config() override;
@@ -46,8 +47,9 @@ class T547 : public PollingComponent, public display::DisplayBuffer {
 
   void eink_off_();
   void eink_on_();
-
-
+  uint32_t full_update_every_;
+  bool quick_updating_;
+  uint32_t quick_updates_{0};
   int get_width_internal() override { return 960; }
 
   int get_height_internal() override { return 540; }


### PR DESCRIPTION
Added quick update for display based on #1 by removing `epd_clear()` from every draw and draw a white screen based on buffer. This will reduce the black/white flashing. The `epd_clear()` is called it only every n-th draw to prevent ghosting.

There are two new option `full_update_every` and `quick_updating`.
Name | Type | Default | Description
--- | --- | --- | ---
quick_updating | bool | false | Toggle the quick updating function.
full_update_every | int | 5 | Sets how many draws will be done before full clear using `epd_clear()`.

It still won't work for Black on White

Sample config:
```
display:
  - platform: t547
    id: t547_display
    quick_updating: true
    full_update_every: 5
```